### PR TITLE
Change 'calliper' to 'caliper'

### DIFF
--- a/info/task_description.html
+++ b/info/task_description.html
@@ -1,7 +1,6 @@
 <p>
-    Nicola discovered a calliper inside a set of drafting tools he received as a gift.
+    Nicola discovered a caliper inside a set of drafting tools he received as a gift.
     Seeing the caliper, he has decided to learn how to use it.
-
 </p>
 <p>
     Through any three points that do not exist on the same line, there lies a unique circle.


### PR DESCRIPTION
Not technically spelled wrong but let's keep it consistent with the other spelling later in the paragraph